### PR TITLE
Using object-level partitions instead of argument-level

### DIFF
--- a/distributed_frontera/worker/partitioner.py
+++ b/distributed_frontera/worker/partitioner.py
@@ -11,15 +11,15 @@ class FingerprintPartitioner(Partitioner):
         digest = unhexlify(key[0:2] + key[5:7] + key[10:12] + key[15:17])
         value = unpack("<I", digest)
         idx = value[0] % size
-        return self.partitions[idx]
+        return self.partitions[idx] if partitions else self.partitions[idx]
 
 
 class Crc32NamePartitioner(Partitioner):
     def partition(self, key, partitions):
         value = crc32(key) if type(key) is str else crc32(key.encode('utf-8', 'ignore'))
-        return self.partition_by_hash(value, partitions)
+        return self.partition_by_hash(value, partitions if partitions else self.partitions)
 
     def partition_by_hash(self, value, partitions):
         size = len(self.partitions)
         idx = value % size
-        return self.partitions[idx]
+        return partitions[idx]

--- a/distributed_frontera/worker/partitioner.py
+++ b/distributed_frontera/worker/partitioner.py
@@ -11,7 +11,7 @@ class FingerprintPartitioner(Partitioner):
         digest = unhexlify(key[0:2] + key[5:7] + key[10:12] + key[15:17])
         value = unpack("<I", digest)
         idx = value[0] % size
-        return partitions[idx]
+        return self.partitions[idx]
 
 
 class Crc32NamePartitioner(Partitioner):
@@ -22,4 +22,4 @@ class Crc32NamePartitioner(Partitioner):
     def partition_by_hash(self, value, partitions):
         size = len(self.partitions)
         idx = value % size
-        return partitions[idx]
+        return self.partitions[idx]


### PR DESCRIPTION
Considering these changes https://github.com/mumrah/kafka-python/pull/314, partitions aren't sent anymore in partition() call.