### PR TITLE
fixed: Using the GitHub repo of `distributed-frontera` for `pip insta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 For Ubuntu:
 ```bash
 $ apt-get install libsnappy-dev
-$ pip install distributed-frontera
+$ pip install git+https://github.com/scrapinghub/distributed-frontera.git
 ```
 
 ## Documentation

--- a/docs/source/topics/quickstart.rst
+++ b/docs/source/topics/quickstart.rst
@@ -23,7 +23,7 @@ Frontera installation
 For Ubuntu, type in command line: ::
 
     $ apt-get install libsnappy-dev
-    $ pip install distributed-frontera
+    $ pip install git+https://github.com/scrapinghub/distributed-frontera.git
 
 
 Checkout a simple Scrapy spider


### PR DESCRIPTION
…ll`, as the package on PYPI is rather outdated

The package on PYPI even tries to use `crawlfrontier`